### PR TITLE
Adding xvfb to allow Firefox based testing

### DIFF
--- a/bin/generate-travis-yml.sh
+++ b/bin/generate-travis-yml.sh
@@ -28,6 +28,10 @@ branches:
 before_install:
 - npm install -g coveralls pr-bumper
 - pr-bumper check
+before_script:
+- "export DISPLAY=:99.0"
+- "sh -e /etc/init.d/xvfb start"
+- sleep 3 # give xvfb some time to start
 install:
 - npm install
 - bower install


### PR DESCRIPTION
A tiny #feature# that allows Firefox based testing by adding the X virtual frame buffer so that the browser has a display to attach to.
